### PR TITLE
Fix several Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,22 +243,6 @@ matrix:
     env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40 CONAN_CURRENT_PAGE=6
   - os: osx
     language: generic
-    osx_image: xcode7.3
-    env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=1
-  - os: osx
-    language: generic
-    osx_image: xcode7.3
-    env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=2
-  - os: osx
-    language: generic
-    osx_image: xcode7.3
-    env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=3
-  - os: osx
-    language: generic
-    osx_image: xcode7.3
-    env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=4
-  - os: osx
-    language: generic
     osx_image: xcode8.3
     env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=1
   - os: osx

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,7 +77,15 @@ class QtConan(ConanFile):
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 
     def source(self):
-        submodules = ["qtbase"]
+        self.run("git clone https://code.qt.io/qt/qt5.git")
+        self.run("cd %s && git checkout %s" % (self.source_dir, self.version))
+        self.run("cd %s && git submodule update --init %s" % (self.source_dir, "qtbase"))
+
+        if self.settings.os != "Windows":
+            self.run("chmod +x ./%s/configure" % self.source_dir)
+
+    def build(self):
+        submodules = []
 
         if self.options.activeqt:
             submodules.append("qtactiveqt")
@@ -108,14 +116,9 @@ class QtConan(ConanFile):
         if self.options.xmlpatterns:
             submodules.append("qtxmlpatterns")
 
-        self.run("git clone https://code.qt.io/qt/qt5.git")
-        self.run("cd %s && git checkout %s" % (self.source_dir, self.version))
-        self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))
+        if len(submodules) > 0:
+            self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))
 
-        if self.settings.os != "Windows":
-            self.run("chmod +x ./%s/configure" % self.source_dir)
-
-    def build(self):
         args = ["-opensource", "-confirm-license", "-nomake examples", "-nomake tests",
                 "-prefix %s" % self.package_folder]
         if not self.options.shared:

--- a/conanfile.py
+++ b/conanfile.py
@@ -161,12 +161,10 @@ class QtConan(ConanFile):
             else:
                 args += ["-openssl-linked"]
 
-            self.run("cd %s && %s && set" % (self.source_dir, vcvars))
-            self.run("cd %s && %s && configure %s"
-                     % (self.source_dir, vcvars, " ".join(args)))
-            self.run("cd %s && %s && %s %s"
-                     % (self.source_dir, vcvars, build_command, " ".join(build_args)))
-            self.run("cd %s && %s && %s install" % (self.source_dir, vcvars, build_command))
+            with tools.chdir(self.source_dir):
+                self.run("%s && configure %s" % (vcvars, " ".join(args)))
+                self.run("%s && %s %s" % (vcvars, build_command, " ".join(build_args)))
+                self.run("%s && %s install" % (vcvars, build_command))
 
     def _build_mingw(self, args):
         env_build = AutoToolsBuildEnvironment(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,13 +35,21 @@ class QtConan(ConanFile):
         "webengine": [True, False],
         "websockets": [True, False],
         "xmlpatterns": [True, False],
+        "declarative": [True, False],
+        "multimedia": [True, False],
+        "doc": [True, False],
+        "repotools": [True, False],
+        "qa": [True, False],
+        "quickcontrols": [True, False],
         "openssl": ["no", "yes", "linked"]
     }
     default_options = "shared=True", "fPIC=True", "opengl=desktop", "activeqt=False", \
                       "canvas3d=False", "connectivity=False", "gamepad=False", \
                       "graphicaleffects=False", "imageformats=False", "location=False", \
                       "serialport=False", "svg=False", "tools=False", "translations=False", \
-                      "webengine=False", "websockets=False", "xmlpatterns=False", "openssl=no"
+                      "webengine=False", "websockets=False", "xmlpatterns=False", "openssl=no", \
+                      "declarative=False", "multimedia=False", "doc=False", "repotools=False", \
+                      "qa=False", "quickcontrols=False"
     short_paths = True
 
     def system_requirements(self):
@@ -115,6 +123,18 @@ class QtConan(ConanFile):
             submodules.append("qtwebsockets")
         if self.options.xmlpatterns:
             submodules.append("qtxmlpatterns")
+        if self.options.declarative:
+            submodules.append("qtdeclarative")
+        if self.options.multimedia:
+            submodules.append("qtmultimedia")
+        if self.options.doc:
+            submodules.append("qtdoc")
+        if self.options.repotools:
+            submodules.append("qtrepotools")
+        if self.options.qa:
+            submodules.append("qtqa")
+        if self.options.quickcontrols:
+            submodules.append("qtquickcontrols")
 
         if len(submodules) > 0:
             self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))


### PR DESCRIPTION
Fix Issue reported by Robert Habrich on Slack.

```
__VSCMD_PREINIT_VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\
**********************************************************************
** Visual Studio 2017 Developer Command Prompt v15.6.4
** Copyright (c) 2017 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'
'configure' is not recognized as an internal or external command,
operable program or batch file.
Qt/5.11@bincrafters/stable:
Qt/5.11@bincrafters/stable: ERROR: Package '6aee9b08c159348af6fa3ce2111ab7da204c5134' build failed
Qt/5.11@bincrafters/stable: WARN: Build folder C:/.conan\ilwkpg\1
ERROR: Qt/5.11@bincrafters/stable: Error in build() method, line 130
        self._build_msvc(args)
while calling '_build_msvc', line 166
        % (self.source_dir, vcvars, " ".join(args)))
        ConanException: Error 1 while executing cd qt5 && set "VSCMD_START_DIR=%CD%" && call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC/Auxiliary/Build/vcvarsall.bat" amd64 && configure -opensource -confirm-license -nomake examples -nomake tests -prefix C:/.conan\ujc9f7\1 -debug -opengl desktop -openssl
```