### PR TITLE
Qt release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -295,10 +295,3 @@ install:
 script:
 - chmod +x .travis/run.sh
 - "./.travis/run.sh"
-
-deploy:
-  provider: bintray
-  user: lucienboillod
-  key:
-    secure: jyatjkww3cgasBfrQKQoYDPUala4v4mD70FqR8zasuvpVn20Urf0YDWwhqXZSMYVQA03Wu8PZV9vwA9xjBmqRWLyAjMucpVcMaHIHyHQmM3QcG6GdWuZYvbC4CipWj5XTI72VW11KKaLQ+xCAJrGcrHjrrKfCMq3FWRY0YDGUCzfih6MF/mTPgyNgUZ12xrqi682BZd6xM5KfiM+3JuHeNbJ46yqZSjemOhX17eye8mmoHCyVUN1r+HLZTup8pNSp7jAyv3m2rvl/pOU5W6ISVGsMsIIMoirvk58zM+O5ncj2RUybA42Yzp8khCP4Rs3+umSP517/M8mmdEg7UrZ82/THufqg1vL6vM/6CVKg+Xt1y5/DaFpfFbRtPx/lWYdCgUxQ5Hq6hXX4wl2b9j04RCOC63+o7qGMOG43eaiGyRx2HasAo7gpE8HqJ0qPiVSAsxNeQJINUvtyFP9t6pD+j3JLyzs7JEymZNOVdLgdpkGl4D1vVdkxolcnEVmPQNihGxdCkU5ytBuASgMiJX6TOHBwgPEL3su77XEl73g2R/9RPmRMd7j2+EX8pREjeWjRTNqvfixbNSJyjswKwolsx8ImNF67e1zFsW/4torhi+vtQkz8zQqLQMBKEcLeGipNJG4eoLq/dPileXUxNUzBcm5+UlCAkjEkqYG2LB0VWM=
-  skip_cleanup: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,11 @@ environment:
     CONAN_TOTAL_PAGES: 6
 
     matrix:
-        - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix'
-        - MINGW_CONFIGURATIONS: '4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix'
-        - MINGW_CONFIGURATIONS: '6.3@x86_64@seh@posix, 7.1@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '4.9@x86_64@sjlj@posix'
+        - MINGW_CONFIGURATIONS: '6@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '8@x86_64@seh@posix'
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,15 @@ environment:
           CONAN_CURRENT_PAGE: 1
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 1
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release
+          CONAN_CURRENT_PAGE: 2
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
           CONAN_CURRENT_PAGE: 2
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
@@ -27,7 +35,15 @@ environment:
           CONAN_CURRENT_PAGE: 3
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 3
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release
+          CONAN_CURRENT_PAGE: 4
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
           CONAN_CURRENT_PAGE: 4
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
@@ -35,7 +51,15 @@ environment:
           CONAN_CURRENT_PAGE: 5
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 5
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release
+          CONAN_CURRENT_PAGE: 6
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
           CONAN_CURRENT_PAGE: 6
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
@@ -60,6 +84,30 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
+          CONAN_CURRENT_PAGE: 6
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 1
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 2
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 3
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 4
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_CURRENT_PAGE: 5
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
           CONAN_CURRENT_PAGE: 6
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,9 @@ environment:
     CONAN_TOTAL_PAGES: 6
 
     matrix:
+        - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix'
+        - MINGW_CONFIGURATIONS: '4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix'
+        - MINGW_CONFIGURATIONS: '6.3@x86_64@seh@posix, 7.1@x86_64@seh@posix'
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
           CONAN_BUILD_TYPES: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,14 @@ environment:
     CONAN_TOTAL_PAGES: 6
 
     matrix:
+        - MINGW_CONFIGURATIONS: '4.9@x86@dwarf2@posix'
         - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix'
         - MINGW_CONFIGURATIONS: '4.9@x86_64@sjlj@posix'
+        - MINGW_CONFIGURATIONS: '6@x86@dwarf2@posix'
         - MINGW_CONFIGURATIONS: '6@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '7@x86@dwarf2@posix'
         - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
+        - MINGW_CONFIGURATIONS: '8@x86@dwarf2@posix'
         - MINGW_CONFIGURATIONS: '8@x86_64@seh@posix'
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14

--- a/conanfile.py
+++ b/conanfile.py
@@ -156,7 +156,7 @@ class QtConan(ConanFile):
             args += ["-openssl"]
         else:
             args += ["-openssl-linked"]
-            if settings.os == "Windows":
+            if self.settings.os == "Windows":
                 args += ["OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
 
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -143,24 +143,28 @@ class QtConan(ConanFile):
             if not getattr(self.options, module[2:]):
                 args.append("-skip " + module)
 
+        # openGL
         if self.options.opengl == "no":
             args += ["-no-opengl"]
         elif self.options.opengl == "es2":
             args += ["-opengl es2"]
         elif self.options.opengl == "desktop":
             args += ["-opengl desktop"]
-
         if self.settings.os == "Windows":
             if self.options.opengl == "dynamic":
                 args += ["-opengl dynamic"]
 
-            if self.options.openssl == "no":
-                args += ["-no-openssl"]
-            elif self.options.openssl == "yes":
-                args += ["-openssl"]
-            else:
-                args += ["-openssl-linked", "OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
+        # openSSL
+        if self.options.openssl == "no":
+            args += ["-no-openssl"]
+        elif self.options.openssl == "yes":
+            args += ["-openssl"]
+        else:
+            args += ["-openssl-linked"]
+            if settings.os == "Windows":
+                args += ["OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
 
+        if self.settings.os == "windows":
             if self.settings.compiler == "Visual Studio":
                 self._build_msvc(args)
             else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -69,16 +69,16 @@ class QtConan(ConanFile):
     def system_requirements(self):
         pack_names = None
         if tools.os_info.linux_distro == "ubuntu":
-            pack_names = ["libx11-6", "libfontconfig1-dev", "libxrender-dev", "libxcursor-dev",
-                          "libxext-dev", "libxfixes-dev", "libxft-dev", "libxi-dev",
-                          "libgl1-mesa-dev", "libxcb1", "libxcb1-dev", "libxrandr-dev",
-                          "libx11-xcb1", "libx11-xcb-dev", "libxcb-keysyms1",
-                          "libxcb-keysyms1-dev", "libxcb-image0", "libxcb-image0-dev",
-                          "libxcb-shm0", "libxcb-shm0-dev", "libxcb-icccm4", "libx11-dev",
-                          "libxcb-icccm4-dev", "libxcb-sync1", "libxcb-sync-dev",
+            pack_names = ["libfontconfig1-dev", "libxrender-dev",
+                          "libxext-dev", "libxfixes-dev", "libxi-dev",
+                          "libgl1-mesa-dev", "libxcb1-dev",
+                          "libx11-xcb-dev",
+                          "libxcb-keysyms1-dev", "libxcb-image0-dev",
+                          "libxcb-shm0-dev", "libx11-dev",
+                          "libxcb-icccm4-dev", "libxcb-sync-dev",
                           "libxcb-xfixes0-dev", "libxcb-shape0-dev", "libxcb-render-util0-dev",
-                          "libxcb-randr0-dev", "libxcb-render-util0",
-                          "libxcb-glx0-dev", "libxcb-xinerama0", "libxcb-xinerama0-dev"]
+                          "libxcb-randr0-dev", 
+                          "libxcb-glx0-dev"]
 
             if self.settings.arch == "x86":
                 pack_names = [item+":i386" for item in pack_names]

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,6 @@
 
 from conans import ConanFile, tools
 from distutils.spawn import find_executable
-from conans import VisualStudioBuildEnvironment
 import os
 import shutil
 
@@ -37,6 +36,7 @@ class QtConan(ConanFile):
         "qtpurchasing",
         "qtquickcontrols",
         "qtquickcontrols2",
+        "qtremoteobjects",
         "qtscript",
         "qtscxml",
         "qtsensors",
@@ -184,15 +184,15 @@ class QtConan(ConanFile):
             build_args = []
         self.output.info("Using '%s %s' to build" % (build_command, " ".join(build_args)))
 
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars):
-            vcvars = tools.vcvars_command(self.settings)
+        
+        vcvars = tools.vcvars_command(self.settings)
 
-            self.run("%s && set" % vcvars)
-            self.run("%s && %s/qt5/configure %s"
-                     % (vcvars, self.source_folder, " ".join(args)))
-            self.run("%s && %s %s"
-                     % (vcvars, build_command, " ".join(build_args)))
-            self.run("%s && %s install" % (vcvars, build_command))
+        self.run("%s && set" % vcvars)
+        self.run("%s && %s/qt5/configure %s"
+                % (vcvars, self.source_folder, " ".join(args)))
+        self.run("%s && %s %s"
+                % (vcvars, build_command, " ".join(build_args)))
+        self.run("%s && %s install" % (vcvars, build_command))
 
     def _build_mingw(self, args):
         # Workaround for configure using clang first if in the path

--- a/conanfile.py
+++ b/conanfile.py
@@ -65,6 +65,7 @@ class QtConan(ConanFile):
     no_copy_source = True
     default_options = ("shared=True", "fPIC=True", "opengl=desktop", "openssl=no") + tuple(module[2:] + "=False" for module in submodules)
     short_paths = True
+    build_policy = "missing"
 
     def build_requirements(self):
         if tools.os_info.is_linux:    
@@ -95,6 +96,7 @@ class QtConan(ConanFile):
         if tools.os_info.is_windows:
             if self.options.openssl == "yes" or self.options.openssl == "linked":
                 self.requires("OpenSSL/1.0.2l@conan/stable")
+                self.options["OpenSSL"].no_zlib = True
         
         if tools.os_info.is_linux:
             pack_names = ["libfontconfig1", "libxrender1",
@@ -168,7 +170,7 @@ class QtConan(ConanFile):
             elif self.options.openssl == "yes":
                 args += ["-openssl"]
             else:
-                args += ["-openssl-linked"]
+                args += ["-openssl-linked", "OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
 
             self.run("%s && set" % vcvars)
             self.run("%s && %s/qt5/configure %s"

--- a/conanfile.py
+++ b/conanfile.py
@@ -132,7 +132,7 @@ class QtConan(ConanFile):
         if not self.options.shared:
             args.insert(0, "-static")
             if self.settings.os == "Windows":
-                if self.settings.compiler.runtime == "MT":
+                if self.settings.compiler.runtime == "MT" or self.settings.compiler.runtime == "MTd":
                     args.append("-static-runtime")
         else:
             args.insert(0, "-shared")

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,11 +87,6 @@ class QtConan(ConanFile):
             installer.update() # Update the package database
             installer.install(" ".join(pack_names)) # Install the package
 
-    def config_options(self):
-        if self.settings.os != "Windows":
-            if self.options.opengl == "dynamic":
-                del self.options.opengl
-
     def requirements(self):
         if self.options.openssl == "yes" or self.options.openssl == "linked":
             self.requires("OpenSSL/1.0.2l@conan/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -164,7 +164,7 @@ class QtConan(ConanFile):
             if settings.os == "Windows":
                 args += ["OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
 
-        if self.settings.os == "windows":
+        if self.settings.os == "Windows":
             if self.settings.compiler == "Visual Studio":
                 self._build_msvc(args)
             else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from distutils.spawn import find_executable
 from conans import AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
 import os
+import shutil
 
 class QtConan(ConanFile):
     name = "Qt"
-    version = "5.11"
+    version = "5.11.0"
     description = "Conan.io package for Qt library."
     url = "https://github.com/lucienboillod/conan-qt"
     license = "http://doc.qt.io/qt-5/lgpl.html"
@@ -17,31 +18,52 @@ class QtConan(ConanFile):
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {
+    submodules = [
+        "qt3d",
+        "qtactiveqt",
+        "qtandroidextras",
+        "qtcanvas3d",
+        "qtcharts",
+        "qtconnectivity",
+        "qtdatavis3d",
+        "qtdeclarative",
+        "qtdoc",
+        "qtgamepad",
+        "qtgraphicaleffects",
+        "qtimageformats",
+        "qtlocation",
+        "qtmacextras",
+        "qtmultimedia",
+        "qtnetworkauth",
+        "qtpurchasing",
+        "qtquickcontrols",
+        "qtquickcontrols2",
+        "qtscript",
+        "qtscxml",
+        "qtsensors",
+        "qtserialbus",
+        "qtserialport",
+        "qtspeech",
+        "qtsvg",
+        "qttools",
+        "qttranslations",
+        "qtvirtualkeyboard",
+        "qtwayland",
+        "qtwebchannel",
+        "qtwebengine",
+        "qtwebsockets",
+        "qtwebview",
+        "qtwinextras",
+        "qtx11extras",
+        "qtxmlpatterns"]
+    options = dict({
         "shared": [True, False],
         "fPIC": [True, False],
         "opengl": ["desktop", "dynamic"],
-        "activeqt": [True, False],
-        "canvas3d": [True, False],
-        "connectivity": [True, False],
-        "gamepad": [True, False],
-        "graphicaleffects": [True, False],
-        "imageformats": [True, False],
-        "location": [True, False],
-        "serialport": [True, False],
-        "svg": [True, False],
-        "tools": [True, False],
-        "translations": [True, False],
-        "webengine": [True, False],
-        "websockets": [True, False],
-        "xmlpatterns": [True, False],
-        "openssl": ["no", "yes", "linked"]
-    }
-    default_options = "shared=True", "fPIC=True", "opengl=desktop", "activeqt=False", \
-                      "canvas3d=False", "connectivity=False", "gamepad=False", \
-                      "graphicaleffects=False", "imageformats=False", "location=False", \
-                      "serialport=False", "svg=False", "tools=False", "translations=False", \
-                      "webengine=False", "websockets=False", "xmlpatterns=False", "openssl=no"
+        "openssl": ["no", "yes", "linked"],
+        }, **{module[2:]: [True,False] for module in submodules}
+    )
+    default_options = ("shared=True", "fPIC=True", "opengl=desktop", "openssl=no") + tuple(module[2:] + "=False" for module in submodules)
     short_paths = True
 
     def system_requirements(self):
@@ -77,43 +99,16 @@ class QtConan(ConanFile):
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 
     def source(self):
-        submodules = ["qtbase"]
-
-        if self.options.activeqt:
-            submodules.append("qtactiveqt")
-        if self.options.canvas3d:
-            submodules.append("qtcanvas3d")
-        if self.options.connectivity:
-            submodules.append("qtconnectivity")
-        if self.options.gamepad:
-            submodules.append("qtgamepad")
-        if self.options.graphicaleffects:
-            submodules.append("qtgraphicaleffects")
-        if self.options.imageformats:
-            submodules.append("qtimageformats")
-        if self.options.location:
-            submodules.append("qtlocation")
-        if self.options.serialport:
-            submodules.append("qtserialport")
-        if self.options.svg:
-            submodules.append("qtsvg")
-        if self.options.tools:
-            submodules.append("qttools")
-        if self.options.translations:
-            submodules.append("qttranslations")
-        if self.options.webengine:
-            submodules.append("qtwebengine")
-        if self.options.websockets:
-            submodules.append("qtwebsockets")
-        if self.options.xmlpatterns:
-            submodules.append("qtxmlpatterns")
-
-        self.run("git clone https://code.qt.io/qt/qt5.git")
-        self.run("cd %s && git checkout %s" % (self.source_dir, self.version))
-        self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))
-
-        if self.settings.os != "Windows":
-            self.run("chmod +x ./%s/configure" % self.source_dir)
+        url = "http://download.qt.io/official_releases/qt/{0}/{1}/single/qt-everywhere-src-{1}"\
+            .format(self.version[:self.version.rfind('.')], self.version)
+        if tools.os_info.is_windows:
+            tools.get("%s.zip" % url)
+        else:
+            installer = tools.SystemPackageTool()
+            installer.update() # Update the package database
+            installer.install("pv")
+            self.run("wget -qO- %s.tar.xz | pv | tar -xJ " % url)
+        shutil.move("qt-everywhere-src-%s" % self.version, self.source_dir)
 
     def build(self):
         args = ["-opensource", "-confirm-license", "-nomake examples", "-nomake tests",
@@ -124,6 +119,9 @@ class QtConan(ConanFile):
             args.append("-debug")
         else:
             args.append("-release")
+        for module in self.submodules:
+            if not getattr(self.options, module[2:]):
+                args.append("-skip " + module)
 
         if self.settings.os == "Windows":
             if self.settings.compiler == "Visual Studio":

--- a/conanfile.py
+++ b/conanfile.py
@@ -129,6 +129,11 @@ class QtConan(ConanFile):
                 "-prefix %s" % self.package_folder]
         if not self.options.shared:
             args.insert(0, "-static")
+            if self.settings.os == "Windows":
+                if self.settings.compiler.runtime == "MT":
+                    args.append("-static-runtime")
+        else:
+            args.insert(0, "-shared")
         if self.settings.build_type == "Debug":
             args.append("-debug")
         else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -145,6 +145,13 @@ class QtConan(ConanFile):
                 args.append("-skip " + module)
 
         if self.settings.os == "Windows":
+            if self.options.openssl == "no":
+                args += ["-no-openssl"]
+            elif self.options.openssl == "yes":
+                args += ["-openssl"]
+            else:
+                args += ["-openssl-linked", "OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
+
             if self.settings.compiler == "Visual Studio":
                 self._build_msvc(args)
             else:
@@ -165,12 +172,6 @@ class QtConan(ConanFile):
             vcvars = tools.vcvars_command(self.settings)
 
             args += ["-opengl %s" % self.options.opengl]
-            if self.options.openssl == "no":
-                args += ["-no-openssl"]
-            elif self.options.openssl == "yes":
-                args += ["-openssl"]
-            else:
-                args += ["-openssl-linked", "OPENSSL_LIBS=\"-lssleay32 -llibeay32 -lGdi32 -lUser32\""]
 
             self.run("%s && set" % vcvars)
             self.run("%s && %s/qt5/configure %s"

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class QtConan(ConanFile):
     name = "Qt"
     version = "5.11.0"
     description = "Conan.io package for Qt library."
-    url = "https://github.com/lucienboillod/conan-qt"
+    url = "https://github.com/bincrafters/conan-qt"
     license = "http://doc.qt.io/qt-5/lgpl.html"
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -19,6 +19,10 @@ class TestPackageConan(ConanFile):
         with tools.environment_append(RunEnvironment(self).vars):
             bin_path = os.path.join("bin", "test_package")
             if self.settings.os == "Windows":
+                if self.settings.compiler == "gcc":
+                    self.run("echo %PATH%")
+                    self.run("ldd %s" % bin_path)
+                    self.run("cd bin && ldd test_package")
                 self.run(bin_path)
             elif self.settings.os == "Macos":
                 self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))


### PR DESCRIPTION
This merge has some big changes over Qt packaging. This PR is on master in order to keep track of the changes, since new branches will be push just after (5.11.0, 5.9.6, and 5.6.3) and old branches will be deleted.

- A new version has been introduced: 5.6.3 (resolve bincrafters/community#295).
- Build is now made out-of-source (resolve bincrafters/community#270).
- Missing essentials sub-modules are now included (resolve bincrafters/community#285).
- Add debug package on bintray (resolve bincrafters/community#313).
- The sources are no more downloaded from git but from Qt archives (officials releases).
- add openSSL support for both windows and linux (resolve bincrafters/community#277).
- add openGL support on unix and add more support on windows (e2s, desktop, dynamic).
- add some MinGW (32 and 64 bits) on the CI.
- add some options (like --static-runtime for windows MT).
- Fix the url and CI deployment.
- Some fixs and minors changes.


Thanks to @ericLemanissier for his work and support over this PR, he did amazing work!
 
