### PR TITLE
Support for openSUSE Leap 15.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -62,7 +62,10 @@ class QtConan(ConanFile):
             elif tools.os_info.is_linux and tools.os_info.linux_distro not in ["arch", "manjaro"]:
                 pack_names = ["libxcb-devel", "libX11-devel", "glibc-devel"]
                 if self.options.opengl == "desktop":
-                    pack_names.append("mesa-libGL-devel")
+                    if (tools.os_info.linux_distro == "opensuse-leap"):
+                        pack_names.append("Mesa-libGL-devel")
+                    else:
+                        pack_names.append("mesa-libGL-devel")
 
             if self.settings.arch == "x86":
                 pack_names = [item+":i386" for item in pack_names]
@@ -100,7 +103,7 @@ class QtConan(ConanFile):
             pack_names = []
             if tools.os_info.linux_distro == "ubuntu" or tools.os_info.linux_distro == "debian": 
                 pack_names = ["libxcb1", "libx11-6"]
-            elif tools.os_info.is_linux and tools.os_info.linux_distro != "opensuse":
+            elif tools.os_info.is_linux and not tools.os_info.linux_distro.startswith("opensuse"):
                 pack_names = ["libxcb"]
 
             if self.settings.arch == "x86":


### PR DESCRIPTION
Needed to change the conanfile, as in leap 15.0 with conan 1.7.3, tools.os_info.linux_distro is
"opensuse-leap".
And the package "mesa-libGL-devel" is written with a different capitalization.
```
$ cat /etc/os-release 
NAME="openSUSE Leap"
VERSION="15.0"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.0"
PRETTY_NAME="openSUSE Leap 15.0"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.0"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```