### PR TITLE
Allow selection of the 'commercial' license on build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -50,6 +50,7 @@ class QtConan(ConanFile):
 
     options = dict({
         "shared": [True, False],
+        "commercial": [True, False],
         "opengl": ["no", "es2", "desktop", "dynamic"],
         "openssl": [True, False],
         "GUI": [True, False],
@@ -58,7 +59,7 @@ class QtConan(ConanFile):
         }, **{module: [True,False] for module in submodules}
     )
     no_copy_source = True
-    default_options = ("shared=True", "opengl=desktop", "openssl=False", "GUI=True", "widgets=True", "config=None") + tuple(module + "=False" for module in submodules)
+    default_options = ("shared=True", "commercial=False", "opengl=desktop", "openssl=False", "GUI=True", "widgets=True", "config=None") + tuple(module + "=False" for module in submodules)
     short_paths = True
     build_policy = "missing"
     
@@ -211,8 +212,12 @@ class QtConan(ConanFile):
         return None
 
     def build(self):
-        args = ["-opensource", "-confirm-license", "-silent", "-nomake examples", "-nomake tests",
+        args = ["-confirm-license", "-silent", "-nomake examples", "-nomake tests",
                 "-prefix %s" % self.package_folder]
+        if self.options.commercial:
+            args.append("-commercial")
+        else:
+            args.append("-opensource")
         if not self.options.GUI:
             args.append("-no-gui")
         if not self.options.widgets:


### PR DESCRIPTION
I would like to be able to build Qt with the commercial license in-lieu of the opensource license. This just adds a 'commercial' option to switch between the two.