### PR TITLE
Allow for 'RelWithDebInfo' build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -231,6 +231,9 @@ class QtConan(ConanFile):
             args.insert(0, "-shared")
         if self.settings.build_type == "Debug":
             args.append("-debug")
+        elif self.settings.build_type == "RelWithDebInfo":
+            args.append("-release")
+            args.append("-force-debug-info")
         else:
             args.append("-release")
         for module in QtConan.submodules:

--- a/conanfile.py
+++ b/conanfile.py
@@ -234,6 +234,9 @@ class QtConan(ConanFile):
         elif self.settings.build_type == "RelWithDebInfo":
             args.append("-release")
             args.append("-force-debug-info")
+        elif self.settings.build_type == "MinSizeRel":
+            args.append("-release")
+            args.append("-optimize-size")
         else:
             args.append("-release")
         for module in QtConan.submodules:


### PR DESCRIPTION
This adds the build type `RelWithDebInfo` and uses Qt's `-force-debug-info` switch to generate debug symbols for release builds. On Windows this will generate a number of `*.pdb` files for all the generated binaries. Those are automagically packaged into the conan binary package for consumption.