### PR TITLE
FIXED: Dependency glib 2.56.1 contains bug fixed in 2.58.3.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -209,7 +209,7 @@ class QtConan(ConanFile):
             self.requires("pcre2/10.32@bincrafters/stable")
 
         if self.options.with_glib:
-            self.requires("glib/2.56.1@bincrafters/stable")
+            self.requires("glib/2.58.3@bincrafters/stable")
             self.options["glib"].shared = True
         # if self.options.with_libiconv:
         #     self.requires("libiconv/1.15@bincrafters/stable")

--- a/conanfile.py
+++ b/conanfile.py
@@ -211,6 +211,7 @@ class QtConan(ConanFile):
         if self.options.with_glib:
             self.requires("glib/2.58.3@bincrafters/stable")
             self.options["glib"].shared = True
+            self.options["glib"].with_pcre = False
         # if self.options.with_libiconv:
         #     self.requires("libiconv/1.15@bincrafters/stable")
         if self.options.with_doubleconversion:


### PR DESCRIPTION
When glib dependency 2.56.1 is required, Qt compilation ends in with
the following error in glib compilation:

    gdbusauth.c:1253:11: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
     1253 |           debug_print ("SERVER: WaitingForData, read '%s'", line);
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    gdbusauth.c:1253:11: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
    gdbusauth.c:1054:11: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
     1054 |           debug_print ("SERVER: WaitingForAuth, read '%s'", line);
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    gdbusauth.c:1054:11: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
    gdbusauth.c:1302:11: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
     1302 |           debug_print ("SERVER: WaitingForBegin, read '%s'", line);
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

See <https://github.com/bincrafters/community/issues/805> for more
information.

The error is fixed by using the glib 2.58.3 dependency.