### PR TITLE
Override pcre2 bzip2 dependency to avoid conflict with freetype

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -207,7 +207,7 @@ class QtConan(ConanFile):
             self.requires("OpenSSL/1.1.1c@conan/stable")
         if self.options.with_pcre2:
             self.requires("pcre2/10.32@bincrafters/stable")
-
+            self.requires("bzip2/1.0.8@conan/stable", override=True)
         if self.options.with_glib:
             self.requires("glib/2.58.3@bincrafters/stable")
         # if self.options.with_libiconv:


### PR DESCRIPTION
Fix bug #939

Override pcre2's dependency on bzip2 v 1.0.6 to v1.0.8 to avoid conflict with freetype.