### PR TITLE
Fix/revert cci dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -222,7 +222,7 @@ class QtConan(ConanFile):
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
             self.requires("double-conversion/3.1.5")
         if self.options.with_freetype and not self.options.multiconfiguration:
-            self.requires("freetype/2.10.0")
+            self.requires("freetype/2.10.0@bincrafters/stable")
         if self.options.with_icu:
             self.requires("icu/64.2@bincrafters/stable")
         if self.options.with_harfbuzz and not self.options.multiconfiguration:

--- a/conanfile.py
+++ b/conanfile.py
@@ -213,14 +213,14 @@ class QtConan(ConanFile):
         if self.options.openssl:
             self.requires("OpenSSL/1.1.1c@conan/stable")
         if self.options.with_pcre2:
-            self.requires("pcre2/10.33")
+            self.requires("pcre2/10.32@bincrafters/stable")
 
         if self.options.with_glib:
             self.requires("glib/2.58.3@bincrafters/stable")
         # if self.options.with_libiconv:
         #     self.requires("libiconv/1.15")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
-            self.requires("double-conversion/3.1.5")
+            self.requires("double-conversion/3.1.4@bincrafters/stable")
         if self.options.with_freetype and not self.options.multiconfiguration:
             self.requires("freetype/2.10.0@bincrafters/stable")
         if self.options.with_icu:
@@ -238,10 +238,10 @@ class QtConan(ConanFile):
             self.requires("mysql-connector-c/6.1.11@bincrafters/stable")
             self.options["mysql-connector-c"].shared = True
         if self.options.with_pq:
-            self.requires("libpq/11.5")
+            self.requires("libpq/11.4@bincrafters/stable")
         if self.options.with_odbc:
-            if self.settings.os != "Windows":
-                self.requires("odbc/2.3.7")
+            self.requires("odbc/2.3.7@bincrafters/stable")
+            self.options["odbc"].shared = (self.settings.os == "Windows")
         if self.options.with_sdl2:
             self.requires("sdl2/2.0.9@bincrafters/stable")
         if self.options.with_openal:
@@ -457,6 +457,8 @@ class QtConan(ConanFile):
                   ("libalsa", "ALSA")]
         for package, var in libmap:
             if package in self.deps_cpp_info.deps:
+                if package == 'odbc' and self.settings.os == "Windows":
+                    continue
                 args.append("\"%s_PREFIX=%s\"" % (var, self.deps_cpp_info[package].rootpath))
                 if package == 'freetype':
                     args.append("\"%s_INCDIR=%s\"" % (var, self.deps_cpp_info[package].include_paths[-1]))

--- a/conanfile.py
+++ b/conanfile.py
@@ -211,7 +211,7 @@ class QtConan(ConanFile):
 
     def requirements(self):
         if self.options.openssl:
-            self.requires("openssl/1.1.1d")
+            self.requires("OpenSSL/1.1.1c@conan/stable")
         if self.options.with_pcre2:
             self.requires("pcre2/10.33")
 
@@ -224,7 +224,7 @@ class QtConan(ConanFile):
         if self.options.with_freetype and not self.options.multiconfiguration:
             self.requires("freetype/2.10.0")
         if self.options.with_icu:
-            self.requires("icu/64.2")
+            self.requires("icu/64.2@bincrafters/stable")
         if self.options.with_harfbuzz and not self.options.multiconfiguration:
             self.requires("harfbuzz/2.6.1@bincrafters/stable")
         if self.options.with_libjpeg and not self.options.multiconfiguration:
@@ -235,7 +235,7 @@ class QtConan(ConanFile):
             self.requires("sqlite3/3.29.0")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.with_mysql:
-            self.requires("mysql-connector-c/6.1.11")
+            self.requires("mysql-connector-c/6.1.11@bincrafters/stable")
             self.options["mysql-connector-c"].shared = True
         if self.options.with_pq:
             self.requires("libpq/11.5")
@@ -405,7 +405,7 @@ class QtConan(ConanFile):
         if not self.options.openssl:
             args += ["-no-openssl"]
         else:
-            if self.options["openssl"].shared:
+            if self.options["OpenSSL"].shared:
                 args += ["-openssl-runtime"]
             else:
                 args += ["-openssl-linked"]
@@ -438,7 +438,7 @@ class QtConan(ConanFile):
                 args += ["-no-" + conf_arg]
 
         libmap = [("zlib", "ZLIB"),
-                  ("openssl", "OPENSSL"),
+                  ("OpenSSL", "OPENSSL"),
                   ("pcre2", "PCRE2"),
                   ("glib", "GLIB"),
                   # ("libiconv", "ICONV"),

--- a/conanfile.py
+++ b/conanfile.py
@@ -119,7 +119,7 @@ class QtConan(ConanFile):
         "multiconfiguration": False,
     }, **{module: False for module in _submodules if module != 'qtbase'}
     )
-    requires = "zlib/1.2.11"
+    requires = "zlib/1.2.11@conan/stable"
     short_paths = True
 
     def _system_package_architecture(self):
@@ -226,13 +226,13 @@ class QtConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/64.2@bincrafters/stable")
         if self.options.with_harfbuzz and not self.options.multiconfiguration:
-            self.requires("harfbuzz/2.6.1@bincrafters/stable")
+            self.requires("harfbuzz/2.4.0@bincrafters/stable")
         if self.options.with_libjpeg and not self.options.multiconfiguration:
-            self.requires("libjpeg/9c")
+            self.requires("libjpeg/9c@bincrafters/stable")
         if self.options.with_libpng and not self.options.multiconfiguration:
-            self.requires("libpng/1.6.37")
+            self.requires("libpng/1.6.37@bincrafters/stable")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
-            self.requires("sqlite3/3.29.0")
+            self.requires("sqlite3/3.28.0@bincrafters/stable")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.with_mysql:
             self.requires("mysql-connector-c/6.1.11@bincrafters/stable")


### PR DESCRIPTION
cci is not ready for stable package, so keep stable dependencies for now to continue to improve conan-qt. cci package could be use in separate "conan channel"/"git branch".