### PR TITLE
Add a option to build Qt with ThreadSanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following command both runs all the steps of the conan file, and publishes t
 | commercial      | False |  [True, False] |
 | opengl      | desktop |  ['no', 'es2', 'desktop', 'dynamic'] |
 | openssl      | True |  [True, False] |
+| sanitize_thread | False | [True, False] |
 | with_pcre2      | True |  [True, False] |
 | with_glib      | True |  [True, False] |
 | with_doubleconversion      | True |  [True, False] |


### PR DESCRIPTION
The Qt configure script provides options to compile Qt with sanitizers.
The idea is to reflect this possibility with options in the Conan recipe.
Naming: sanitize_thread correspond to -sanitize thread
I currently only added ThreadSanitizer, to keep the changes little.