### PR TITLE
Fix Qt 5.12.7 Windows issue (add patch fixing QTBUG-81715)

### DIFF
--- a/8a3fde0.diff
+++ b/8a3fde0.diff
@@ -1,0 +1,20 @@
+diff --git a/src/corelib/Qt5CoreMacros.cmake b/src/corelib/Qt5CoreMacros.cmake
+index 7735e51..b3da640 100644
+--- a/src/corelib/Qt5CoreMacros.cmake
++++ b/src/corelib/Qt5CoreMacros.cmake
+@@ -59,7 +59,14 @@
+     set(_outfile "${CMAKE_CURRENT_BINARY_DIR}/${rel}")
+     string(REPLACE ".." "__" _outfile ${_outfile})
+     get_filename_component(outpath ${_outfile} PATH)
+-    string(REGEX REPLACE "\\.[^.]*$" "" _outfile ${_outfile})
++    if(CMAKE_VERSION VERSION_LESS "3.14")
++        get_filename_component(_outfile_ext ${_outfile} EXT)
++        get_filename_component(_outfile_ext ${_outfile_ext} NAME_WE)
++        get_filename_component(_outfile ${_outfile} NAME_WE)
++        string(APPEND _outfile ${_outfile_ext})
++    else()
++        get_filename_component(_outfile ${_outfile} NAME_WLE)
++    endif()
+     file(MAKE_DIRECTORY ${outpath})
+     set(${outfile} ${outpath}/${prefix}${_outfile}.${ext})
+ endmacro()

--- a/8a3fde0.diff
+++ b/8a3fde0.diff
@@ -1,8 +1,30 @@
+From 8a3fde00bf53d99e9e4853e8ab97b0e1bcf74915 Mon Sep 17 00:00:00 2001
+From: Joerg Bornemann <joerg.bornemann@qt.io>
+Date: Wed, 29 Jan 2020 11:06:35 +0100
+Subject: [PATCH] Fix qt5_make_output_file macro for paths containing dots
+
+Commit 89bd5a7e broke CMake projects that use dots in their build
+paths, because the used regular expression matches the directory part
+of the path as well.
+
+The regex wants to achieve the same as get_filename_component(...
+NAME_WLE) which is available since CMake 3.14. Re-implement the
+NAME_WLE functionality for older CMake versions by using multiple
+get_filename_component calls.
+
+Fixes: QTBUG-81715
+Task-number: QTBUG-80295
+Change-Id: I2ef053300948f6e1b2c0c5eafac35105f193d4e6
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ src/corelib/Qt5CoreMacros.cmake | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
 diff --git a/src/corelib/Qt5CoreMacros.cmake b/src/corelib/Qt5CoreMacros.cmake
-index 7735e51..b3da640 100644
+index 7735e51012b..b3da6406a18 100644
 --- a/src/corelib/Qt5CoreMacros.cmake
 +++ b/src/corelib/Qt5CoreMacros.cmake
-@@ -59,7 +59,14 @@
+@@ -59,7 +59,14 @@ macro(QT5_MAKE_OUTPUT_FILE infile prefix ext outfile )
      set(_outfile "${CMAKE_CURRENT_BINARY_DIR}/${rel}")
      string(REPLACE ".." "__" _outfile ${_outfile})
      get_filename_component(outpath ${_outfile} PATH)
@@ -18,3 +40,5 @@ index 7735e51..b3da640 100644
      file(MAKE_DIRECTORY ${outpath})
      set(${outfile} ${outpath}/${prefix}${_outfile}.${ext})
  endmacro()
+--
+2.16.3

--- a/conanfile.py
+++ b/conanfile.py
@@ -293,7 +293,7 @@ class QtConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         shutil.move("qt-everywhere-src-%s" % self.version, "qt5")
 
-        for patch in ["cc04651dea4c4678c626cb31b3ec8394426e2b25.diff"]:
+        for patch in ["cc04651dea4c4678c626cb31b3ec8394426e2b25.diff", "8a3fde0.diff"]:
             tools.patch("qt5/qtbase", patch)
         for patch in ["a9cc8aa.diff"]:
             tools.patch("qt5/qtmultimedia", patch)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,13 +7,18 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed
 set(CMAKE_AUTOMOC ON)
+# Instruct CMake to run rcc automatically when needed
+set (CMAKE_AUTORCC ON)
 # Create code from a list of Qt designer ui files
 set(CMAKE_AUTOUIC ON)
 
 # Find the QtCore library
 find_package(Qt5Core CONFIG REQUIRED)
 
-add_executable(${PROJECT_NAME} test_package.cpp greeter.h)
+# Make sure resource files work
+qt5_add_resources(TEST_RESOURCES test.qrc)
+
+add_executable(${PROJECT_NAME} test_package.cpp greeter.h ${TEST_RESOURCES})
 target_link_libraries(${PROJECT_NAME} Qt5::Core)
 
 # configure_file(${CMAKE_CURRENT_BINARY_DIR}/qt.conf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf COPYONLY)

--- a/test_package/test.qrc
+++ b/test_package/test.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>test_package.cpp</file>
+    </qresource>
+</RCC>

--- a/test_package/test_package.pro
+++ b/test_package/test_package.pro
@@ -2,6 +2,8 @@ SOURCES += test_package.cpp
 
 HEADERS += greeter.h
 
+RESOURCES += test.qrc
+
 QT -= GUI
 
 CONFIG += console


### PR DESCRIPTION
There was a bug in Qt 5.12, which was supposed to be fixed in https://bugreports.qt.io/browse/QTBUG-80295 , however this fix caused applications using a Qt CMake Macro to not build anymore.
Specifically, .qrc files could not be parsed anymore on Windows.

This behaviour was reported in https://bugreports.qt.io/browse/QTBUG-81715 but apparently the fix was too late to be merged into the hotfix release, so it remains broken in Qt 5.12.7.

This PR applies the resulting patch.