### PR TITLE
FIX: Insert QMAKE_ build variables into mkspecs (qmake.conf) 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import itertools
+import time
+import math
 
 import configparser
 from conans import ConanFile, tools, __version__ as conan_version, RunEnvironment
@@ -647,9 +649,9 @@ class QtConan(ConanFile):
             if not qmake_args or self.settings.os != "Macos":
                 return spec
 
+            custom_mkspec = "conan-" + str(math.floor(time.time()))
             source_mkspec_path = target_mkspec_path = \
                 os.path.join(self.source_folder, "qt5", "qtbase", "mkspecs", sub_path)
-            custom_mkspec = "conan-" + self.info.package_id()
 
             source_mkspec_path = os.path.join(source_mkspec_path, spec)
             target_mkspec_path = os.path.join(target_mkspec_path, custom_mkspec)


### PR DESCRIPTION
I noticed that `QMAKE_...` variables are not honoured when building this recipe (at least on macOS). That leads to the fact that environment variables (like `CC`, `CXX`, `CXXFLAGS` and the like) don't have any effect on the Qt build. Hence, it currently doesn't seem possible to _actually_ change the compiler and its flags when building Qt via this recipe.

I briefly skimmed through Qt's top-level `./configure` script and apparently they do special handling for macOS (and more specifically Xcode). Potentially this is interferring with the way this recipe tries to set up the Qt build.

To fix that, I successfully tuned the `qmake.conf` files in `qtbase/mkspecs` by simply appending all configured `QMAKE_...` variables to the existing `qmake.conf` file. This fiddles around in the original source tree, so measures have been taken to allow multiple builds from the same source tree.

I'm opening this as a 'Draft'-PR in the hope of feedback on whether there is a better way of making the compiler and its flags configurable on macOS (and potentially other platforms).