### PR TITLE
FIX: Premature adaption of qt.conf breaks .package()

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -690,7 +690,7 @@ class QtConan(ConanFile):
 
     def package(self):
         self.run("%s install" % self._make_program())
-        with open(os.path.join(self.package_folder, 'bin/qt.conf', 'w')) as f:
+        with open(os.path.join(self.package_folder, "bin", "qt.conf"), 'w') as f:
             f.write('[Paths]\nPrefix = ..\n')
         self.copy("*LICENSE*", src="qt5/", dst="licenses")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -688,11 +688,10 @@ class QtConan(ConanFile):
                     }) if tools.os_info.is_macos else tools.no_op():
                     self.run(self._make_program(), run_environment=True)
 
-        with open('qtbase/bin/qt.conf', 'w') as f:
-            f.write('[Paths]\nPrefix = ..')
-
     def package(self):
         self.run("%s install" % self._make_program())
+        with open('qtbase/bin/qt.conf', 'w') as f:
+            f.write('[Paths]\nPrefix = ..')
         self.copy("bin/qt.conf", src="qtbase")
         self.copy("*LICENSE*", src="qt5/", dst="licenses")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -690,9 +690,8 @@ class QtConan(ConanFile):
 
     def package(self):
         self.run("%s install" % self._make_program())
-        with open('qtbase/bin/qt.conf', 'w') as f:
-            f.write('[Paths]\nPrefix = ..')
-        self.copy("bin/qt.conf", src="qtbase")
+        with open(os.path.join(self.package_folder, 'bin/qt.conf', 'w')) as f:
+            f.write('[Paths]\nPrefix = ..\n')
         self.copy("*LICENSE*", src="qt5/", dst="licenses")
 
     def package_id(self):


### PR DESCRIPTION
[Yesterday's commit](https://github.com/bincrafters/conan-qt/commit/0fc2c916cb9a0715a39b90b1b1043fbc2b02067a) broke our build of this recipe, because the `make install` of qtmacextras failed. It didn't find certain "features" while trying to process the module's pro file.

Note however, that we're using the adaption discussed in https://github.com/bincrafters/conan-qt/pull/53.