### PR TITLE
Update: harfbuzz dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog describes interface changes (options and requirements) in the con
 
 ## Unreleased
 ## [5.15.0](https://bintray.com/bincrafters/public-conan/qt%3Abincrafters/5.15.0%3Astable)
+- upgrade to `harfbuzz/2.6.7@bincrafters/stable` [2020-06-09](https://github.com/bincrafters/conan-qt/commit/1a3d13e2e92c81c774a194dc6457e62b4f31bb79)
 - linux: make `xlib` requirement shared by default - [2020-06-08](https://github.com/bincrafters/conan-qt/commit/cb1d1e914c0191803e21da9c81ef71de0d7e52c7)
 - linux: migrate to `fontconfig/2.13.91` - [2020-06-04](https://github.com/bincrafters/conan-qt/commit/2fe7f984af734fb175a9ecffa14e81ae49a22dbd)
 - linux/macos: migrate to build requirement `flex/2.6.4` - [2020-05-21](https://github.com/bincrafters/conan-qt/commit/750851425c3f4217365f5a9aaa9d856e6533fdfd#diff-2b1d42f71f22b7ea0412d7602dec166f)

--- a/conanfile.py
+++ b/conanfile.py
@@ -303,7 +303,7 @@ class QtConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/64.2")
         if self.options.with_harfbuzz and not self.options.multiconfiguration:
-            self.requires("harfbuzz/2.6.4@bincrafters/stable")
+            self.requires("harfbuzz/2.6.7@bincrafters/stable")
         if self.options.with_libjpeg and not self.options.multiconfiguration:
             self.requires("libjpeg/9d")
         if self.options.with_libpng and not self.options.multiconfiguration:


### PR DESCRIPTION
After the swift [update of the harfbuzz recipe](https://github.com/bincrafters/community/issues/1215) earlier today (thanks for that!), I'd like to have Qt depend on the latest version. Since 2.6.6 harfbuzz contains [a patch for a compilation issue](https://github.com/harfbuzz/harfbuzz/pull/2382) when using Clang 9. That would free us from explicitly updating/overriding harfbuzz in our end-user conanfile.