### PR TITLE
Fix libs and includedirs for cmake_find_package_multi generator

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -670,8 +670,8 @@ class QtConan(ConanFile):
 
         self.cpp_info.libs = tools.collect_libs(self)
 
-        # Not sure why, but "Qt5Bootstrap.lib" need to be removed in order to 
-        # Release configuration links successfully
+        # "Qt5Bootstrap.lib" contains symbols that are also in "Qt5Core.lib",
+        # removing it so linker succeed.
         if 'Qt5Bootstrap' in self.cpp_info.libs:
             self.cpp_info.libs.remove('Qt5Bootstrap')
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -668,6 +668,22 @@ class QtConan(ConanFile):
     def package_info(self):
         self.env_info.CMAKE_PREFIX_PATH.append(self.package_folder)
 
+        self.cpp_info.libs = tools.collect_libs(self)
+
+        # Not sure why, but "Qt5Bootstrap.lib" need to be removed in order to 
+        # Release configuration links successfully
+        if 'Qt5Bootstrap' in self.cpp_info.libs:
+            self.cpp_info.libs.remove('Qt5Bootstrap')
+
+        # Add top level include directory, so code compile if someone uses
+        # includes with prefixes (e.g. "#include <QtCore/QString>")
+        self.cpp_info.includedirs = ['include']
+
+        # Add all Qt module directories (QtCore, QtGui, QtWidgets and so on), so prefix
+        # can be omited in includes (e.g. "#include <QtCore/QString>" => "#include <QString>")
+        fu = ['include/' + f.name for f in os.scandir('include') if f.is_dir()]
+        self.cpp_info.includedirs.extend(fu)
+
     @staticmethod
     def _remove_duplicate(l):
         seen = set()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(qt REQUIRED CONFIG)
 #below macros are missing and probably unnecessary when using "find_package(qt...)"
 #conan_set_vs_runtime()
 #conan_set_libcxx()
-conan_output_dirs_setup()
+#conan_output_dirs_setup()
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,7 +4,9 @@ project(test_package)
 # Below lines are to fix this error:
 #     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
 #     "Compile your code with -fPIC (-fPIE is not enough)."
-conan_message(STATUS "Conan: Adjusting fPIC flag (${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})")
+#
+# Why conan_message() is unknown for this context? Removing it...
+#conan_message(STATUS "Conan: Adjusting fPIC flag (${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})")
 set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
 
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,8 +4,9 @@ project(test_package)
 #include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
 find_package(qt REQUIRED CONFIG)
 
+#below macros are missing and probably unnecessary when using "find_package(qt...)"
 #conan_set_vs_runtime()
-conan_set_libcxx()
+#conan_set_libcxx()
 conan_output_dirs_setup()
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(test_package)
 
+# Below lines are to fix this error:
+#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
+#     "Compile your code with -fPIC (-fPIE is not enough)."
+conan_message(STATUS "Conan: Adjusting fPIC flag (${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})")
+set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
+
+
 #include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
 find_package(qt REQUIRED CONFIG)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package)
 #include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
 find_package(qt REQUIRED CONFIG)
 
-conan_set_vs_runtime()
+#conan_set_vs_runtime()
 conan_set_libcxx()
 conan_output_dirs_setup()
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+#include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+find_package(qt REQUIRED CONFIG)
+
 conan_set_vs_runtime()
 conan_set_libcxx()
 conan_output_dirs_setup()
@@ -16,12 +18,17 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 # Find the QtCore library
-find_package(Qt5Core CONFIG REQUIRED)
+#find_package(Qt5Core CONFIG REQUIRED)
+# "find_package(Qt5 COMPONENTS Widgets)" or "find_package(Qt5 COMPONENTS Core)" or maybe other can be used
+# in order to AUTOMOC, AUTOUIC and AUTORCC be enabled / works correctly
+find_package(Qt5 COMPONENTS Core)
 
 add_executable(${PROJECT_NAME} test_package.cpp greeter.h)
-target_link_libraries(${PROJECT_NAME} Qt5::Core)
+#target_link_libraries(${PROJECT_NAME} Qt5::Core)
+target_link_libraries(${PROJECT_NAME} qt::qt)
 
 # configure_file(${CMAKE_CURRENT_BINARY_DIR}/qt.conf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf COPYONLY)
 
 message(">>>>>>>> CMAKE_VERSION ${CMAKE_VERSION}")
 message(">>>>>>>> CMAKE_CXX_STANDARD_LIBRARIES ${CMAKE_CXX_STANDARD_LIBRARIES}")
+

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conans.errors import ConanException
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "qt", "cmake"
+    generators = "qt", "cmake", "cmake_find_package_multi"
 
     def build_requirements(self):
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -110,8 +110,11 @@ class TestPackageConan(ConanFile):
     def _test_with_cmake(self):
         if self._cmake_supported():
             self.output.info("Testing CMake")
-            shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
-            self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
+            # shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
+            # self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
+            # Executable for cmake_find_package_multi on VS2019 is provided to differetn folder - correcting path
+            shutil.copy("qt.conf", "cmake_folder")
+            self.run(os.path.join("cmake_folder", "test_package"), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings, skip_x64_x86=True):


### PR DESCRIPTION
This change is needed to correctly support cmake_find_package_multi generator.

Qt implementation in CMakeLists.txt (in package consumer) for cmake_find_package_multi generator is:
```
find_package(qt REQUIRED CONFIG)

set(CMAKE_AUTOMOC ON)
set(CMAKE_AUTORCC ON)
set(CMAKE_AUTOUIC ON)

# "find_package(Qt5 COMPONENTS Widgets)" or "find_package(Qt5 COMPONENTS Core)" or maybe other can be used
# in order to AUTOMOC, AUTOUIC and AUTORCC be enabled / works correctly
find_package(Qt5 COMPONENTS Core)

target_link_libraries(MyProgram
    qt::qt
)
```