### PR TITLE
Fix libs and includedirs for cmake_find_package_multi generator 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -697,6 +697,10 @@ class QtConan(ConanFile):
             self.cpp_info.system_libs.append('Netapi32')  # 'Qt5Cored.lib' require 'NetApiBufferFree' which is in 'Netapi32.lib' library
             self.cpp_info.system_libs.append('UserEnv')   # 'Qt5Cored.lib' require '__imp_GetUserProfileDirectoryW ' which is in 'UserEnv.Lib' library
 
+        if self.settings.os == 'Macos':
+            self.cpp_info.frameworks.extend(["IOKit"])    # 'libQt5Core.a' require '_IORegistryEntryCreateCFProperty', '_IOServiceGetMatchingService' and much more which are in 'IOKit' framework
+            self.cpp_info.frameworks.extend(["Cocoa"])    # 'libQt5Core.a' require '_OBJC_CLASS_$_NSApplication' and more, which are in 'Cocoa' framework
+            self.cpp_info.frameworks.extend(["Security"]) # 'libQt5Core.a' require '_SecRequirementCreateWithString' and more, which are in 'Security' framework
 
     @staticmethod
     def _remove_duplicate(l):

--- a/conanfile.py
+++ b/conanfile.py
@@ -677,7 +677,7 @@ class QtConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
 
         # "Qt5Bootstrap.lib" contains symbols that are also in "Qt5Core.lib",
-        # removing it so linker succeed.
+        # Linking to both, cause linker failure, so removing "Qt5Bootstrap".
         if 'Qt5Bootstrap' in self.cpp_info.libs:
             self.cpp_info.libs.remove('Qt5Bootstrap')
 
@@ -690,17 +690,17 @@ class QtConan(ConanFile):
         fu = ['include/' + f.name for f in os.scandir('include') if f.is_dir()]
         self.cpp_info.includedirs.extend(fu)
 
-        # Should it be some extra 'if' here like "if not self.options.shared" or for generator type "cmake_find_package_multi" vs "cmake"?
-        if self.settings.os == 'Windows':
-            self.cpp_info.system_libs.append('Version')   # 'Qt5Cored.lib' require 'GetFileVersionInfoW' and 'VerQueryValueW' which are in 'Version.lib' library
-            self.cpp_info.system_libs.append('Winmm')     # 'Qt5Cored.lib' require '__imp_timeSetEvent' which is in 'Winmm.lib' library
-            self.cpp_info.system_libs.append('Netapi32')  # 'Qt5Cored.lib' require 'NetApiBufferFree' which is in 'Netapi32.lib' library
-            self.cpp_info.system_libs.append('UserEnv')   # 'Qt5Cored.lib' require '__imp_GetUserProfileDirectoryW ' which is in 'UserEnv.Lib' library
+        if not self.options.shared:
+            if self.settings.os == 'Windows':
+                self.cpp_info.system_libs.append('Version')   # 'Qt5Cored.lib' require 'GetFileVersionInfoW' and 'VerQueryValueW' which are in 'Version.lib' library
+                self.cpp_info.system_libs.append('Winmm')     # 'Qt5Cored.lib' require '__imp_timeSetEvent' which is in 'Winmm.lib' library
+                self.cpp_info.system_libs.append('Netapi32')  # 'Qt5Cored.lib' require 'NetApiBufferFree' which is in 'Netapi32.lib' library
+                self.cpp_info.system_libs.append('UserEnv')   # 'Qt5Cored.lib' require '__imp_GetUserProfileDirectoryW ' which is in 'UserEnv.Lib' library
 
-        if self.settings.os == 'Macos':
-            self.cpp_info.frameworks.extend(["IOKit"])    # 'libQt5Core.a' require '_IORegistryEntryCreateCFProperty', '_IOServiceGetMatchingService' and much more which are in 'IOKit' framework
-            self.cpp_info.frameworks.extend(["Cocoa"])    # 'libQt5Core.a' require '_OBJC_CLASS_$_NSApplication' and more, which are in 'Cocoa' framework
-            self.cpp_info.frameworks.extend(["Security"]) # 'libQt5Core.a' require '_SecRequirementCreateWithString' and more, which are in 'Security' framework
+            if self.settings.os == 'Macos':
+                self.cpp_info.frameworks.extend(["IOKit"])    # 'libQt5Core.a' require '_IORegistryEntryCreateCFProperty', '_IOServiceGetMatchingService' and much more which are in 'IOKit' framework
+                self.cpp_info.frameworks.extend(["Cocoa"])    # 'libQt5Core.a' require '_OBJC_CLASS_$_NSApplication' and more, which are in 'Cocoa' framework
+                self.cpp_info.frameworks.extend(["Security"]) # 'libQt5Core.a' require '_SecRequirementCreateWithString' and more, which are in 'Security' framework
 
     @staticmethod
     def _remove_duplicate(l):

--- a/conanfile.py
+++ b/conanfile.py
@@ -690,6 +690,13 @@ class QtConan(ConanFile):
         fu = ['include/' + f.name for f in os.scandir('include') if f.is_dir()]
         self.cpp_info.includedirs.extend(fu)
 
+        # Should it be some extra 'if' here like "if not self.options.shared" or for generator type "cmake_find_package_multi" vs "cmake"?
+        if self.settings.os == 'Windows':
+            self.cpp_info.system_libs.append('Version')   # 'Qt5Cored.lib' require 'GetFileVersionInfoW' and 'VerQueryValueW' which are in 'Version.lib' library
+            self.cpp_info.system_libs.append('Winmm')     # 'Qt5Cored.lib' require '__imp_timeSetEvent' which is in 'Winmm.lib' library
+            self.cpp_info.system_libs.append('Netapi32')  # 'Qt5Cored.lib' require 'NetApiBufferFree' which is in 'Netapi32.lib' library
+
+
     @staticmethod
     def _remove_duplicate(l):
         seen = set()

--- a/conanfile.py
+++ b/conanfile.py
@@ -664,7 +664,7 @@ class QtConan(ConanFile):
                 tools.rmdir(os.path.join(self.package_folder, "licenses", module))
         # "Qt5Bootstrap" is internal Qt library - removing it to avoid linking error, since it contains
         # symbols that are also in "Qt5Core.lib". It looks like there is no "Qt5Bootstrap.dll".
-        for fl in glob.glob(os.path.join(self.package_folder, "lib", "Qt5Bootstrap.*")):
+        for fl in glob.glob(os.path.join(self.package_folder, "lib", "*Qt5Bootstrap*")):
             os.remove(fl)
 
     def package_id(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -695,6 +695,7 @@ class QtConan(ConanFile):
             self.cpp_info.system_libs.append('Version')   # 'Qt5Cored.lib' require 'GetFileVersionInfoW' and 'VerQueryValueW' which are in 'Version.lib' library
             self.cpp_info.system_libs.append('Winmm')     # 'Qt5Cored.lib' require '__imp_timeSetEvent' which is in 'Winmm.lib' library
             self.cpp_info.system_libs.append('Netapi32')  # 'Qt5Cored.lib' require 'NetApiBufferFree' which is in 'Netapi32.lib' library
+            self.cpp_info.system_libs.append('UserEnv')   # 'Qt5Cored.lib' require '__imp_GetUserProfileDirectoryW ' which is in 'UserEnv.Lib' library
 
 
     @staticmethod

--- a/conanfile.py
+++ b/conanfile.py
@@ -674,6 +674,22 @@ class QtConan(ConanFile):
     def package_info(self):
         self.env_info.CMAKE_PREFIX_PATH.append(self.package_folder)
 
+        self.cpp_info.libs = tools.collect_libs(self)
+
+        # "Qt5Bootstrap.lib" contains symbols that are also in "Qt5Core.lib",
+        # removing it so linker succeed.
+        if 'Qt5Bootstrap' in self.cpp_info.libs:
+            self.cpp_info.libs.remove('Qt5Bootstrap')
+
+        # Add top level include directory, so code compile if someone uses
+        # includes with prefixes (e.g. "#include <QtCore/QString>")
+        self.cpp_info.includedirs = ['include']
+
+        # Add all Qt module directories (QtCore, QtGui, QtWidgets and so on), so prefix
+        # can be omited in includes (e.g. "#include <QtCore/QString>" => "#include <QString>")
+        fu = ['include/' + f.name for f in os.scandir('include') if f.is_dir()]
+        self.cpp_info.includedirs.extend(fu)
+
     @staticmethod
     def _remove_duplicate(l):
         seen = set()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.1.0)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# Below lines are to fix this error:
+#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
+#     "Compile your code with -fPIC (-fPIE is not enough)."
+#set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
+
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
@@ -12,14 +20,6 @@ conan_output_dirs_setup()
 find_package(qt REQUIRED CONFIG)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
-# Below lines are to fix this error:
-#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
-#     "Compile your code with -fPIC (-fPIE is not enough)."
-#set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -35,6 +35,7 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt5 COMPONENTS Core)
 
 add_executable(${PROJECT_NAME} test_package.cpp greeter.h)
+target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
 #target_link_libraries(${PROJECT_NAME} Qt5::Core)
 target_link_libraries(${PROJECT_NAME} qt::qt)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(test_package)
 
-# Below lines are to fix this error:
-#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
-#     "Compile your code with -fPIC (-fPIE is not enough)."
-set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
-
-
 include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
 conan_set_vs_runtime()
 conan_set_libcxx()
@@ -15,6 +9,12 @@ conan_output_dirs_setup()
 find_package(qt REQUIRED CONFIG)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+# Below lines are to fix this error:
+#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
+#     "Compile your code with -fPIC (-fPIE is not enough)."
+#set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 #     "Compile your code with -fPIC (-fPIE is not enough)."
 #set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -2,13 +2,7 @@ cmake_minimum_required(VERSION 3.1.0)
 
 set(CMAKE_CXX_STANDARD 11)
 
-# Below lines are to fix this error:
-#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
-#     "Compile your code with -fPIC (-fPIE is not enough)."
-#set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
+#set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(test_package)
 
@@ -19,8 +13,6 @@ conan_output_dirs_setup()
 
 find_package(qt REQUIRED CONFIG)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed
@@ -28,15 +20,13 @@ set(CMAKE_AUTOMOC ON)
 # Create code from a list of Qt designer ui files
 set(CMAKE_AUTOUIC ON)
 
-# Find the QtCore library
-#find_package(Qt5Core CONFIG REQUIRED)
-# "find_package(Qt5 COMPONENTS Widgets)" or "find_package(Qt5 COMPONENTS Core)" or maybe other can be used
-# in order to AUTOMOC, AUTOUIC and AUTORCC be enabled / works correctly
+# Find the QtCore library in order to AUTOMOC, AUTOUIC and AUTORCC be enabled / works correctly
 find_package(Qt5 COMPONENTS Core)
 
 add_executable(${PROJECT_NAME} test_package.cpp greeter.h)
+# Must compile with "-fPIC" since Qt was built with -reduce-relocations.
 target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
-#target_link_libraries(${PROJECT_NAME} Qt5::Core)
+
 target_link_libraries(${PROJECT_NAME} qt::qt)
 
 # configure_file(${CMAKE_CURRENT_BINARY_DIR}/qt.conf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf COPYONLY)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,11 +1,21 @@
 cmake_minimum_required(VERSION 3.1.0)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
-conan_set_vs_runtime()
-conan_set_libcxx()
-conan_output_dirs_setup()
+# Below lines are to fix this error:
+#     error: "You must build your code with position independent code if Qt was built with -reduce-relocations. "
+#     "Compile your code with -fPIC (-fPIE is not enough)."
+set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
 
+
+#include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+find_package(qt REQUIRED CONFIG)
+
+#below macros are missing and probably unnecessary when using "find_package(qt...)"
+#conan_set_vs_runtime()
+#conan_set_libcxx()
+#conan_output_dirs_setup()
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -15,10 +25,14 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
 # Find the QtCore library
-find_package(Qt5Core CONFIG REQUIRED)
+#find_package(Qt5Core CONFIG REQUIRED)
+# "find_package(Qt5 COMPONENTS Widgets)" or "find_package(Qt5 COMPONENTS Core)" or maybe other can be used
+# in order to AUTOMOC, AUTOUIC and AUTORCC be enabled / works correctly
+find_package(Qt5 COMPONENTS Core)
 
 add_executable(${PROJECT_NAME} test_package.cpp greeter.h)
-target_link_libraries(${PROJECT_NAME} Qt5::Core)
+#target_link_libraries(${PROJECT_NAME} Qt5::Core)
+target_link_libraries(${PROJECT_NAME} qt::qt)
 
 # configure_file(${CMAKE_CURRENT_BINARY_DIR}/qt.conf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/qt.conf COPYONLY)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,7 +7,7 @@ project(test_package)
 set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
 
 
-include(${CMAKE_BINARY_DIR}/../conanbuildinfo_multi.cmake)
+include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
 conan_set_vs_runtime()
 conan_set_libcxx()
 conan_output_dirs_setup()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0)
+
+set(CMAKE_CXX_STANDARD 11)
+
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,13 +7,12 @@ project(test_package)
 set(CMAKE_POSITION_INDEPENDENT_CODE ${CONAN_CMAKE_POSITION_INDEPENDENT_CODE})
 
 
-#include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
-find_package(qt REQUIRED CONFIG)
+include(${CMAKE_BINARY_DIR}/../conanbuildinfo_multi.cmake)
+conan_set_vs_runtime()
+conan_set_libcxx()
+conan_output_dirs_setup()
 
-#below macros are missing and probably unnecessary when using "find_package(qt...)"
-#conan_set_vs_runtime()
-#conan_set_libcxx()
-#conan_output_dirs_setup()
+find_package(qt REQUIRED CONFIG)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conans.errors import ConanException
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "qt", "cmake"
+    generators = "qt", "cmake", "cmake_find_package_multi"
 
     def build_requirements(self):
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":
@@ -110,8 +110,11 @@ class TestPackageConan(ConanFile):
     def _test_with_cmake(self):
         if self._cmake_supported():
             self.output.info("Testing CMake")
-            shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
-            self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
+            # shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
+            # self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
+            # Executable for cmake_find_package_multi on VS2019 is provided to differetn folder - correcting path
+            shutil.copy("qt.conf", "cmake_folder")
+            self.run(os.path.join("cmake_folder", "test_package"), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings, skip_x64_x86=True):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -112,9 +112,6 @@ class TestPackageConan(ConanFile):
             self.output.info("Testing CMake")
             shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
             self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
-            # Executable for cmake_find_package_multi on VS2019 is provided to differetn folder - correcting path
-            # shutil.copy("qt.conf", "cmake_folder")
-            # self.run(os.path.join("cmake_folder", "test_package"), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings, skip_x64_x86=True):

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -110,11 +110,11 @@ class TestPackageConan(ConanFile):
     def _test_with_cmake(self):
         if self._cmake_supported():
             self.output.info("Testing CMake")
-            # shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
-            # self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
+            shutil.copy("qt.conf", os.path.join("cmake_folder", "bin"))
+            self.run(os.path.join("cmake_folder", "bin", "test_package"), run_environment=True)
             # Executable for cmake_find_package_multi on VS2019 is provided to differetn folder - correcting path
-            shutil.copy("qt.conf", "cmake_folder")
-            self.run(os.path.join("cmake_folder", "test_package"), run_environment=True)
+            # shutil.copy("qt.conf", "cmake_folder")
+            # self.run(os.path.join("cmake_folder", "test_package"), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings, skip_x64_x86=True):


### PR DESCRIPTION
Continuation of PR #59 for details see #59
It is the same as PR #59 except now changes base on Qt 5.15.1 instead of 5.15.0

PR build error, unrelated to change, is:
```
ERROR: Missing binary: fontconfig/2.13.91:1f25be57f7980db35dd7b7d3c0b4e8f05a6bc2ac
ERROR: Missing binary: harfbuzz/2.6.8:3c029ab4199af7d5184f59b0a6828e32ecd3fc09
```
however is strange since branch `testing/1.15.1` was built successfully 3 days ago and those packages were not missing ([link](https://github.com/bincrafters/conan-qt/runs/1188620885)).

fixes bincrafters/community#1290

I was able successfully build Qt package locally in VS2019 by adding `--build=harfbuzz`, while `fontconfig` is not needed on Win.