### PR TITLE
update glib version to glib/2.66.0 to resolve conflict with harfbuzz

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -288,7 +288,7 @@ class QtConan(ConanFile):
             self.requires("pcre2/10.33")
 
         if self.options.with_glib:
-            self.requires("glib/2.65.1")
+            self.requires("glib/2.66.0")
         # if self.options.with_libiconv:
         #     self.requires("libiconv/1.16")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:


### PR DESCRIPTION
harfbuzz/2.6.8 depends on glib/2.66.0 but qt depends glib/2.65.1
