### PR TITLE
Adds bindir to environment

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -682,6 +682,9 @@ class QtConan(ConanFile):
 
     def package_info(self):
         self.env_info.CMAKE_PREFIX_PATH.append(self.package_folder)
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Append %s to environment variable PATH" % bindir)
+        self.env_info.PATH.append(bindir)
 
     @staticmethod
     def _remove_duplicate(l):


### PR DESCRIPTION
This fixes use in Qt Creator. Alternatively we could set QT_QMAKE_EXECUTABLE but I think this is more natural (similar to the requirement in https://git.sailfishos.org/mer-core/telepathy-qt/blob/6f0177bc024f3f7bce94c0abc283fba1c3b8a0d1/cmake/modules/FindQt5.cmake). Maybe users want to use more executables in the bin dir.

Fixes https://github.com/bincrafters/community/issues/1292